### PR TITLE
mod gitignore to ignore the Dungeon Sprites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+## Dungeon Sprites
+/Dungeon_Crawl_Stone_Soup_Full
+
 ## Java
 
 *.class


### PR DESCRIPTION
This is assuming the Dungeon Sprite folder: "Dungeon_Crawl_Stone_Soup_Full" resides in the same folder as your gitignore